### PR TITLE
treat rules as objects instead of strings

### DIFF
--- a/src/js/action/ask-question-data.directive.js
+++ b/src/js/action/ask-question-data.directive.js
@@ -3,9 +3,11 @@
 
   function syncRules(rules, actionRules) {
     angular.forEach(rules, function(rule) {
-      if (actionRules.indexOf(rule.name) !== -1) {
-        rule.checked = true;
-      }
+      angular.forEach(actionRules, function(actionRule) {
+        if (actionRule.name === rule.name) {
+          rule.checked = true;
+        }
+      });
     });
   }
 
@@ -50,7 +52,7 @@
 
             angular.forEach(scope.rules, function(value) {
               if (value.checked) {
-                scope.action.data.rules.push(value.name);
+                scope.action.data.rules.push({name: value.name});
               }
             });
           }, true);


### PR DESCRIPTION
To make it work with the latest API. Does not yet support range rules.
